### PR TITLE
setup.py: fix entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     package_data={'qweechat': ['data/icons/*.png']},
     entry_points = {
         'gui_scripts': [
-            'qweechat = qweechat.qweechat',
+            'qweechat = qweechat.qweechat:main',
         ],
         'console_scripts': [
             'qweechat-testproto = qweechat.weechat.testproto:main',


### PR DESCRIPTION
Won't install without a valid callable suffix.

Figured this out while packaging for nix: https://github.com/NixOS/nixpkgs/pull/18094